### PR TITLE
docs(auth): document multi-step token exchange

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,9 +117,9 @@ scanning_strategy:
     session_dir: ~/.vigolium/sessions/
     use_in_discovery: true       # apply session headers during discovery/spidering
     compare_enabled: true        # cross-session IDOR/BOLA replay in dynamic-assessment
-    reauth_interval: ""          # e.g. "15m" to refresh tokens periodically
-    reauth_on_status: []         # e.g. [401, 403]
-    validate_url: ""             # URL to GET after login to verify credentials
+    reauth_interval: ""          # reserved; currently not enforced
+    reauth_on_status: []         # reserved; currently not enforced
+    validate_url: ""             # reserved; currently not enforced
 
   http:
     user_agent: preset           # preset | random | literal value; blank behaves like random

--- a/docs/guides/scanning-an-api.md
+++ b/docs/guides/scanning-an-api.md
@@ -105,7 +105,7 @@ vigolium scan --input api.yaml -I openapi -t https://api.example.com \
   -H "Authorization: Bearer <token>"
 ```
 
-For login flows, cookie sessions, token refresh, and role comparison, see
+For single- and multi-step login flows, cookie sessions, and role comparison, see
 [Native Scan Authentication](../native-scan/authentication.md).
 
 ## Recommended Strategy

--- a/docs/native-scan/authentication.md
+++ b/docs/native-scan/authentication.md
@@ -140,6 +140,87 @@ login:
 }
 ```
 
+### Multi-Step Login Flows
+
+Use `login.steps` when authentication requires more than one HTTP request. Steps
+run in order with a shared cookie jar. To pass a value to a later step, extract
+it with `apply_as: "var:<name>"`, then reference it as `{name}` in a later
+step's URL or body. The final step must extract at least one credential that
+Vigolium can apply to scan requests.
+
+The following provider-backed flow models applications that first receive a
+short-lived identity-provider token and then exchange it for an application
+token. Stytch B2B password discovery uses this shape: the authenticate response
+contains `intermediate_session_token`, and the application exchange endpoint
+returns the application's final token.
+
+```yaml
+sessions:
+  - name: dev_user
+    role: primary
+    login:
+      steps:
+        # Step 1: authenticate with the identity provider.
+        - url: "https://identity.example.com/passwords/discovery/authenticate"
+          method: POST
+          content_type: "application/json"
+          body: >-
+            {"email_address":"${TEST_EMAIL}","password":"${TEST_PASSWORD}"}
+          expect:
+            status: [200]
+            body_contains: "intermediate_session_token"
+          extract:
+            - source: json
+              path: "$.intermediate_session_token"
+              apply_as: "var:intermediate_session_token"
+
+        # Step 2: exchange the intermediate token for the app token.
+        - url: "https://api.example.com/auth/stytch/exchange"
+          method: POST
+          content_type: "application/json"
+          body: >-
+            {"intermediate_session_token":"{intermediate_session_token}"}
+          expect:
+            status: [200]
+            body_contains: "token"
+          extract:
+            - source: json
+              path: "$.token"
+              apply_as: "Authorization: Bearer {value}"
+
+            # Keep this rule only when the application also requires a cookie.
+            - source: json
+              path: "$.token"
+              apply_as: "Cookie: token={value}"
+```
+
+In a browser trace, calls such as Stytch's `sdk/v1/projects/bootstrap` initialize
+the browser SDK and do not produce the authenticated application session. Do
+not add them as login steps unless a later authentication request genuinely
+depends on a value they return. Likewise, an `/auth/me` request verifies the
+finished session; it is not part of the token exchange itself.
+
+Each step may use `expect.status` and `expect.body_contains` to fail early when
+the remote service changes behavior. `vigolium auth lint` checks the file's
+structure only; the remote requests and extraction rules are exercised when a
+scan hydrates the session.
+
+```bash
+vigolium auth lint ./multi-step-token-exchange.yaml
+vigolium scan \
+  https://app.example.com \
+  https://api.example.com \
+  --auth-file ./multi-step-token-exchange.yaml \
+  --scope-origin strict
+```
+
+> **Per-step header limitation:** a multi-step login step currently supports
+> `url`, `method`, `content_type`, `body`, `extract`, and `expect`, but not
+> arbitrary request headers. Browser SDK endpoints that require Basic auth,
+> `Origin`, or SDK-specific headers cannot always be reproduced directly. Use
+> an authorized server-side test endpoint or a pre-acquired static token rather
+> than putting secrets in the URL.
+
 ### Extraction Sources
 
 | Source | Description | Example |
@@ -147,8 +228,17 @@ login:
 | `json` | Extract a value from the JSON response body using dot-notation. | `path: "$.token"` |
 | `cookie` | Extract cookies from `Set-Cookie` response headers. Omit `name` to extract all cookies. | `name: "session_id"` |
 | `header` | Extract a value from a response header. | `name: "X-Auth-Token"` |
+| `regex` | Extract a capture group from the response body. Group 1 is used by default. | `pattern: 'token="([^"]+)"'` |
 
-The `apply_as` field defines how the extracted value is applied as a request header. Use `{value}` as a placeholder.
+The `apply_as` field defines how the extracted value is used. A header template
+such as `Authorization: Bearer {value}` applies it to scan requests. In a
+multi-step flow, `var:name` stores it for `{name}` substitution in later step
+URLs and bodies.
+
+`source: cookie` reads `Set-Cookie` response headers. It cannot observe a cookie
+created later by frontend JavaScript. If an exchange endpoint returns a token
+in JSON and the frontend turns it into a cookie, extract the JSON value and use
+`apply_as: "Cookie: token={value}"` instead.
 
 ## Bundle Files
 
@@ -281,15 +371,27 @@ SessionConfig
 │   ├── role                # (string) "primary" or "compare"
 │   ├── headers             # (map) Static headers, e.g. {"Cookie": "sid=abc"}
 │   ├── login               # (object) Automated login flow
-│   │   ├── url             # (string, required) Login endpoint URL
-│   │   ├── method          # (string, required) HTTP method (POST, GET, etc.)
+│   │   ├── url             # (string) Single-step login endpoint URL
+│   │   ├── method          # (string) Single-step HTTP method
 │   │   ├── content_type    # (string) Request Content-Type
 │   │   ├── body            # (string) Request body
-│   │   └── extract[]       # (array, required) Credential extraction rules
-│   │       ├── source      # (string) "json", "cookie", or "header"
-│   │       ├── name        # (string) Cookie/header name to extract
-│   │       ├── path        # (string) JSONPath for json source
-│   │       └── apply_as    # (string) Header template, e.g. "Authorization: Bearer {value}"
+│   │   ├── type            # (string) "bearer" or "cookie" shorthand
+│   │   ├── token_path      # (string) Token path used by bearer shorthand
+│   │   ├── expect          # (object) status[] and/or body_contains
+│   │   ├── extract[]       # (array) Credential extraction rules
+│   │   │   ├── source      # (string) "json", "cookie", "header", or "regex"
+│   │   │   ├── name        # (string) Cookie/header name to extract
+│   │   │   ├── path        # (string) JSON path for json source
+│   │   │   ├── pattern     # (string) Pattern for regex source
+│   │   │   ├── group       # (int) Regex capture group; defaults to 1
+│   │   │   └── apply_as    # (string) Header template or "var:name"
+│   │   └── steps[]         # (array) Sequential multi-step flow
+│   │       ├── url         # (string, required) Step endpoint URL
+│   │       ├── method      # (string, required) Step HTTP method
+│   │       ├── content_type # (string) Step request Content-Type
+│   │       ├── body        # (string) Supports {name} variables
+│   │       ├── expect      # (object) status[] and/or body_contains
+│   │       └── extract[]   # (array; required on the final step)
 │   └── login_request       # (string) Raw HTTP request for login (alternative to login)
 ```
 
@@ -382,6 +484,33 @@ vigolium scan https://app.com \
 | Discovery / Spidering | Primary session only (controlled by `use_in_discovery`) |
 | DynamicAssessment | Primary session for main scanning; compare sessions for IDOR/BOLA replay (controlled by `compare_enabled`) |
 
+## Validation and Troubleshooting
+
+| Symptom | Meaning and next step |
+|---------|-----------------------|
+| `auth lint` succeeds but scan hydration fails | Lint validates structure without contacting the login services. Check the failing step's status, response shape, and extraction path. |
+| `cookie "token" not found in login response` | The response did not include a matching `Set-Cookie` header. If it returned JSON, use `source: json`; if browser JavaScript creates the cookie, build the `Cookie` header with `apply_as`. |
+| A later request still contains `{name}` | The earlier rule did not use `apply_as: "var:name"`, or its extraction path did not match. Variable names are case-sensitive. |
+| `last step must have at least one extract rule` | Add a final extraction that produces an application header or cookie. Intermediate variables alone are not scan credentials. |
+| The banner prints a scan ID, then `session initialization failed` | The scan stopped before discovery or assessment. The scan ID does not mean findings were produced. |
+| Requests include another environment | Use `--scope-origin strict`, especially when the active project already contains records from several environments. |
+
+Do not print response bodies while debugging production credentials. Prefer a
+dedicated test account and rotate credentials that have appeared in shell
+history, logs, or support transcripts.
+
+## Current Authentication Limitations
+
+- Login flows are hydrated once during scan initialization. The configured
+  `reauth_interval`, `reauth_on_status`, and `validate_url` fields are reserved
+  but are not currently enforced during native scans. Ensure a token's lifetime
+  covers the scan or divide a long scan into shorter runs.
+- Pass multi-step configurations directly with `--auth-file`. `vigolium auth
+  load` currently validates and persists only single-step login fields, so a
+  stored multi-step flow will not round-trip correctly.
+- Multi-step variables are substituted only in subsequent step URLs and bodies.
+  Arbitrary per-step headers are not part of the current schema.
+
 ## Session Strategy Configuration
 
 Session behavior is configured under `scanning_strategy.session` in `vigolium-configs.yaml` (see `public/vigolium-configs.example.yaml` for the full annotated example).
@@ -408,21 +537,13 @@ scanning_strategy:
     # Default: true
     compare_enabled: true
 
-    # Re-execute login flows at this interval to refresh expiring tokens.
-    # Format: Go duration string (e.g. "15m", "1h", "30m").
-    # Default: "" (disabled — login once at scan start)
+    # Reserved for future runtime reauthentication; currently not enforced.
     reauth_interval: ""
 
-    # Trigger reactive re-authentication when the primary session receives
-    # one of these HTTP status codes. The login flow is re-executed immediately
-    # and the failed request is retried.
-    # Default: [] (disabled)
+    # Reserved for future runtime reauthentication; currently not enforced.
     reauth_on_status: []
 
-    # URL to GET after login to verify that extracted credentials work.
-    # The scanner checks for a 2xx response before proceeding.
-    # Can be a relative path (resolved against the target) or absolute URL.
-    # Default: "" (disabled)
+    # Reserved for future post-login validation; currently not enforced.
     validate_url: ""
 ```
 
@@ -433,9 +554,9 @@ scanning_strategy:
 | `session_dir` | string | `~/.vigolium/sessions/` | Directory for session file lookup. `--auth-file myapp` (bare name) resolves to `<session_dir>/myapp.yaml` (tries `.yaml`, `.yml`, `.json` in order). Supports `~` expansion. |
 | `use_in_discovery` | bool | `true` | When `true`, the primary session's headers are injected into the requester used for discovery and spidering. When `false`, those phases run unauthenticated — useful for mapping the public attack surface first, then scanning authenticated. |
 | `compare_enabled` | bool | `true` | When `true`, compare sessions are created and the `authz-compare` module is activated for IDOR/BOLA testing. When `false`, compare sessions are ignored even if defined — handy when you only need authenticated scanning without authorization comparison. |
-| `reauth_interval` | duration | `""` (disabled) | Go duration string (e.g. `"15m"`, `"1h"`). When set, login flows are re-executed at this interval to refresh tokens that expire mid-scan. |
-| `reauth_on_status` | []int | `[]` (disabled) | HTTP status codes that trigger reactive re-authentication. When the primary session receives one of these codes, its login flow is re-executed immediately and the request is retried. |
-| `validate_url` | string | `""` (disabled) | Relative or absolute URL to GET after login. The scanner checks for a 2xx response to confirm credentials are working before proceeding. Catches bad credentials early. |
+| `reauth_interval` | duration | `""` | Reserved; currently not enforced during native scans. |
+| `reauth_on_status` | []int | `[]` | Reserved; currently not enforced during native scans. |
+| `validate_url` | string | `""` | Reserved; currently not enforced during native scans. |
 
 ### Session Directory Resolution
 
@@ -479,18 +600,6 @@ scanning_strategy:
 ```
 
 Useful when you only need to scan behind a login wall but don't have multiple user roles to compare. The primary session's credentials are applied to all phases, but no compare requesters are created and the `authz-compare` module stays inactive.
-
-**Long-running scan with token refresh:**
-
-```yaml
-scanning_strategy:
-  session:
-    reauth_interval: "30m"
-    reauth_on_status: [401, 403]
-    validate_url: "/api/whoami"
-```
-
-Re-executes login flows every 30 minutes proactively, and also reactively when a 401 or 403 is received. The `validate_url` confirms credentials work after each login before resuming scanning.
 
 **Team shared sessions directory:**
 

--- a/internal/config/scanning_strategy.go
+++ b/internal/config/scanning_strategy.go
@@ -77,18 +77,14 @@ type SessionStrategyConfig struct {
 	// cross-session IDOR/BOLA replay during the audit phase. Default: true.
 	CompareEnabled bool `yaml:"compare_enabled"`
 
-	// ReauthInterval re-executes login flows at this interval to refresh
-	// expiring tokens. Zero or empty means login once at scan start.
-	// Accepts Go duration strings (e.g. "15m", "1h").
+	// ReauthInterval is reserved for future runtime reauthentication.
+	// Native scans currently hydrate login flows once during initialization.
 	ReauthInterval string `yaml:"reauth_interval"`
 
-	// ReauthOnStatus triggers re-authentication when the primary session
-	// receives one of these HTTP status codes mid-scan. Common values: [401, 403].
+	// ReauthOnStatus is reserved for future reactive reauthentication.
 	ReauthOnStatus []int `yaml:"reauth_on_status"`
 
-	// ValidateURL is a relative or absolute URL to GET after login to confirm
-	// that extracted credentials are working. The scanner checks for a 2xx
-	// response before proceeding. Empty means no validation.
+	// ValidateURL is reserved for future post-login credential validation.
 	ValidateURL string `yaml:"validate_url"`
 }
 

--- a/pkg/cli/extensions_example.go
+++ b/pkg/cli/extensions_example.go
@@ -620,23 +620,37 @@ sessions:
           pattern: 'token="([^"]+)"'
           apply_as: "Authorization: Bearer {value}"
 
-  # Multi-step: fetch a CSRF token (into var:csrf), then submit the login
-  - name: csrf_app_user
+  # Multi-step: authenticate with an identity provider, then exchange its
+  # intermediate token for the application's final credentials
+  - name: token_exchange_user
     role: compare
     login:
       steps:
-        - url: "https://app.com/login"
-          method: GET
-          extract:
-            - source: regex
-              pattern: 'name="csrf_token" value="([^"]+)"'
-              apply_as: "var:csrf"
-        - url: "https://app.com/login"
+        - url: "https://identity.example.com/passwords/discovery/authenticate"
           method: POST
-          content_type: "application/x-www-form-urlencoded"
-          body: "username=user1&password=pass123&csrf_token={csrf}"
+          content_type: "application/json"
+          body: '{"email_address":"${TEST_EMAIL}","password":"${TEST_PASSWORD}"}'
+          expect:
+            status: [200]
+            body_contains: "intermediate_session_token"
           extract:
-            - source: cookie
+            - source: json
+              path: "$.intermediate_session_token"
+              apply_as: "var:intermediate_session_token"
+        - url: "https://api.example.com/auth/stytch/exchange"
+          method: POST
+          content_type: "application/json"
+          body: '{"intermediate_session_token":"{intermediate_session_token}"}'
+          expect:
+            status: [200]
+            body_contains: "token"
+          extract:
+            - source: json
+              path: "$.token"
+              apply_as: "Authorization: Bearer {value}"
+            - source: json
+              path: "$.token"
+              apply_as: "Cookie: token={value}"
 
   # Static token, no login request needed
   - name: api_key_user
@@ -718,14 +732,14 @@ sessions:
     # Replay primary requests with compare sessions for IDOR/BOLA
     compare_enabled: true
 
-    # Re-run login flows on this Go-duration interval ("" = login once)
+    # Reserved for future runtime reauthentication; currently not enforced
     reauth_interval: ""
 
-    # Reactively re-authenticate when these status codes are seen
-    reauth_on_status: [401, 403]
+    # Reserved for future reactive reauthentication; currently not enforced
+    reauth_on_status: []
 
-    # GET this URL after login to verify credentials (2xx expected; "" = off)
-    validate_url: "/api/me"`,
+    # Reserved for future post-login validation; currently not enforced
+    validate_url: ""`,
 		},
 	}
 }

--- a/public/presets/prompts/autopilot/autopilot-system-prompt.md
+++ b/public/presets/prompts/autopilot/autopilot-system-prompt.md
@@ -38,7 +38,7 @@ printf 'POST /api HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/jso
 echo "curl -X POST https://example.com/api -d '{}'" | vigolium scan-request --json
 ```
 
-For authenticated scans, pass `--auth-file <name>` (DB-stored session, bare name or path) or `--auth 'name:Header:value'` (inline). Both flags are repeatable and are available on `scan` and `run`. For `scan-url` / `scan-request`, pass credentials as explicit headers instead (e.g. `-H 'Authorization: Bearer <token>'` on `scan-url`, or include the header in the raw request for `scan-request`).
+For authenticated scans, pass `--auth-file <name-or-path>` (a YAML/JSON session file; bare names resolve against `session_dir`) or `--auth 'name:Header:value'` (inline). Both flags are repeatable and are available on `scan` and `run`. For `scan-url` / `scan-request`, pass credentials as explicit headers instead (e.g. `-H 'Authorization: Bearer <token>'` on `scan-url`, or include the header in the raw request for `scan-request`).
 
 **4. Results — Query and manage findings**
 
@@ -69,12 +69,15 @@ cat /tmp/findings.json | vigolium finding load
 Configure authenticated scanning by using prepared session/auth artifacts when present. Only create or repair a session config yourself when preflight did not already prepare one:
 
 ```
-# Load session config from file
-cat session-config.json | vigolium auth load
-
-# Validate session config syntax before loading
+# Validate a session config before using it
 vigolium auth lint session-config.json
 cat session-config.json | vigolium auth lint --stdin
+
+# Pass session config directly to a native scan
+vigolium scan https://target.example --auth-file session-config.json
+
+# Persist static or single-step sessions for later scans
+vigolium auth load session-config.json --host target.example
 
 # List loaded auth sessions
 vigolium auth ls --json
@@ -93,7 +96,7 @@ vigolium auth totp --secret <base32-secret>
       "login": {
         "url": "https://target.com/api/login",
         "method": "POST",
-        "body": "{\"email\":\"admin@example.com\",\"password\":\"admin123\"}",
+        "body": "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\"}",
         "type": "bearer",
         "token_path": ".authentication.token",
         "expect": {"status": [200]}
@@ -105,7 +108,7 @@ vigolium auth totp --secret <base32-secret>
       "login": {
         "url": "https://target.com/api/login",
         "method": "POST",
-        "body": "{\"email\":\"user@example.com\",\"password\":\"pass123\"}",
+        "body": "{\"email\":\"${USER_EMAIL}\",\"password\":\"${USER_PASSWORD}\"}",
         "type": "bearer",
         "token_path": ".authentication.token"
       }
@@ -114,7 +117,7 @@ vigolium auth totp --secret <base32-secret>
 }
 ```
 
-Create one session entry per role/credential. `"primary"` is used for scanning; `"compare"` for authorization/IDOR testing. Supports `"type": "bearer"`, `"cookie"`, and multi-step flows with `"steps"` array. Always lint before loading: `vigolium auth lint session-config.json`.
+Create one session entry per role/credential. `"primary"` is used for scanning; `"compare"` for authorization/IDOR testing. Supports `"type": "bearer"`, `"cookie"`, and multi-step flows with a `"steps"` array. Always lint before use. Pass multi-step configs directly with `--auth-file`; `auth load` currently persists only single-step login fields.
 
 **7. JavaScript Extensions — Custom scanning logic**
 
@@ -216,8 +219,8 @@ You decide your own workflow. Here's how to think about it:
 
 **Set up authentication early:**
 - If prepared auth artifacts already exist, use them first before attempting manual login discovery
-- If the app has login and no prepared auth exists, create a session config and load it with `vigolium auth load`
-- Use `vigolium auth lint` to validate before loading
+- If the app has login and no prepared auth exists, create a session config, lint it, and pass it directly to scans with `--auth-file`
+- Use `vigolium auth load` only when persistence is needed and the config contains static or single-step sessions
 - Primary role for scanning, compare role for IDOR/authorization testing
 
 **Be targeted, not exhaustive:**
@@ -252,7 +255,7 @@ You decide your own workflow. Here's how to think about it:
 ### Output Guidelines
 
 - Always use `--json` flag for vigolium commands to get structured output
-- Always lint extensions and session configs before loading (`vigolium ext lint`, `vigolium auth lint`)
+- Always lint extensions and session configs before use (`vigolium ext lint`, `vigolium auth lint`)
 - Chain commands freely: pipes, redirects, and standard Unix tools
 - **Every finding MUST include proof-of-concept evidence:**
   - Dynamic: full HTTP request and response (method, URL, headers, body)

--- a/public/presets/sessions/login-flow-example.yaml
+++ b/public/presets/sessions/login-flow-example.yaml
@@ -3,6 +3,7 @@
 # Usage:
 #   vigolium scan https://app.com --auth-file ~/.vigolium/sessions/login-flow-example.yaml
 #   vigolium scan https://app.com --auth-file login-flow-example   # bare name resolved against session_dir
+# See multi-step-token-exchange.yaml for an identity-provider-to-app exchange.
 
 sessions:
   # Primary session: login via JSON API, extract Bearer token (shorthand)
@@ -35,7 +36,7 @@ sessions:
       url: "https://app.com/legacy/login"
       method: POST
       content_type: "application/x-www-form-urlencoded"
-      body: "user=legacy&pass=legacy123"
+      body: "user=${LEGACY_USER}&pass=${LEGACY_PASS}"
       extract:
         - source: regex
           pattern: 'token="([^"]+)"'
@@ -55,7 +56,7 @@ sessions:
         - url: "https://app.com/login"
           method: POST
           content_type: "application/x-www-form-urlencoded"
-          body: "username=user1&password=pass123&csrf_token={csrf}"
+          body: "username=${CSRF_USER}&password=${CSRF_PASS}&csrf_token={csrf}"
           extract:
             - source: cookie
 

--- a/public/presets/sessions/multi-step-token-exchange.yaml
+++ b/public/presets/sessions/multi-step-token-exchange.yaml
@@ -1,0 +1,51 @@
+# Example two-step identity-provider to application token exchange.
+# This models flows such as Stytch B2B password discovery:
+#   1. authenticate and extract an intermediate_session_token
+#   2. exchange it for the application's bearer token and/or token cookie
+#
+# Replace the example hosts with authorized test endpoints and export the test
+# credentials before scanning. The identity endpoint must be callable without
+# arbitrary per-step headers; the current multi-step schema cannot set them.
+#
+# Usage:
+#   export TEST_EMAIL='scanner@example.com'
+#   export TEST_PASSWORD='replace-me'
+#   vigolium auth lint ./multi-step-token-exchange.yaml
+#   vigolium scan https://app.example.com https://api.example.com \
+#     --auth-file ./multi-step-token-exchange.yaml --scope-origin strict
+
+sessions:
+  - name: token_exchange_user
+    role: primary
+    login:
+      steps:
+        - url: "https://identity.example.com/passwords/discovery/authenticate"
+          method: POST
+          content_type: "application/json"
+          body: >-
+            {"email_address":"${TEST_EMAIL}","password":"${TEST_PASSWORD}"}
+          expect:
+            status: [200]
+            body_contains: "intermediate_session_token"
+          extract:
+            - source: json
+              path: "$.intermediate_session_token"
+              apply_as: "var:intermediate_session_token"
+
+        - url: "https://api.example.com/auth/stytch/exchange"
+          method: POST
+          content_type: "application/json"
+          body: >-
+            {"intermediate_session_token":"{intermediate_session_token}"}
+          expect:
+            status: [200]
+            body_contains: "token"
+          extract:
+            - source: json
+              path: "$.token"
+              apply_as: "Authorization: Bearer {value}"
+
+            # Remove this rule when the target uses bearer authentication only.
+            - source: json
+              path: "$.token"
+              apply_as: "Cookie: token={value}"

--- a/public/skills/vigolium-scanner/references/auth.md
+++ b/public/skills/vigolium-scanner/references/auth.md
@@ -94,7 +94,7 @@ sessions:
 | `path` | string | JSONPath expression (for json source) |
 | `pattern` | string | Regex pattern with capture group (for regex source) |
 | `group` | int | Capture group index, default 1 (for regex source) |
-| `apply_as` | string | Header template, e.g. `"Authorization: Bearer {value}"` |
+| `apply_as` | string | Header template such as `"Authorization: Bearer {value}"`, or `"var:name"` for use by a later login step |
 
 ## Managing Sessions with `vigolium auth`
 
@@ -116,7 +116,7 @@ cat login-req.txt | vigolium auth load --name admin --host example.com
 # Skip login flow validation
 vigolium auth load sessions.json --no-validate
 
-# Validate session config syntax before loading
+# Validate session config syntax before use
 vigolium auth lint auth-config.yaml
 cat session-config.json | vigolium auth lint --stdin
 
@@ -127,6 +127,11 @@ vigolium auth ls --host example.com
 # Generate TOTP code for 2FA login flows
 vigolium auth totp --secret JBSWY3DPEHPK3PXP
 ```
+
+`auth lint` validates the configuration structure without executing remote
+login requests. Pass multi-step configurations directly to scans with
+`--auth-file`; `auth load` currently validates and persists only single-step
+login fields, so a stored multi-step flow will not round-trip correctly.
 
 ### `vigolium auth load` Flags
 
@@ -288,30 +293,68 @@ sessions:
 
 ### Multi-Step Login Flow
 
-For applications requiring multiple requests to authenticate (e.g., CSRF token + login):
+Steps execute in sequence with a shared cookie jar. Extract an intermediate
+value with `apply_as: "var:name"`, then reference it as `{name}` in a later
+step's URL or body. The last step must extract the headers or cookies used by
+scan requests.
+
+This example models an identity-provider login followed by an application token
+exchange, including Stytch-style `intermediate_session_token` flows:
 
 ```yaml
 sessions:
-  - name: csrf_login
+  - name: dev_user
     role: primary
     login:
       steps:
-        - url: https://example.com/login
-          method: GET
-          extract:
-            - source: regex
-              pattern: 'name="csrf_token" value="([^"]+)"'
-              apply_as: "X-CSRF-Token: {value}"
-            - source: cookie
-              name: session_id
-        - url: https://example.com/login
+        - url: https://identity.example.com/passwords/discovery/authenticate
           method: POST
-          content_type: application/x-www-form-urlencoded
-          body: "username=admin&password=secret&csrf_token={csrf_token}"
+          content_type: application/json
+          body: >-
+            {"email_address":"${TEST_EMAIL}","password":"${TEST_PASSWORD}"}
+          expect:
+            status: [200]
+            body_contains: "intermediate_session_token"
           extract:
-            - source: cookie
-              name: session_id
+            - source: json
+              path: "$.intermediate_session_token"
+              apply_as: "var:intermediate_session_token"
+
+        - url: https://api.example.com/auth/stytch/exchange
+          method: POST
+          content_type: application/json
+          body: >-
+            {"intermediate_session_token":"{intermediate_session_token}"}
+          expect:
+            status: [200]
+            body_contains: "token"
+          extract:
+            - source: json
+              path: "$.token"
+              apply_as: "Authorization: Bearer {value}"
+            - source: json
+              path: "$.token"
+              apply_as: "Cookie: token={value}"
 ```
+
+Stytch's browser SDK bootstrap request initializes the SDK; it is not normally
+one of the authentication steps. A later `/auth/me` request is useful for
+manual verification, but it is not part of the token exchange.
+
+If the exchange response contains JSON rather than a `Set-Cookie` header, use
+`source: json`. `source: cookie` cannot observe a cookie created later by
+frontend JavaScript.
+
+### Current Limitations
+
+- Login flows hydrate once when a native scan starts. The configured
+  `reauth_interval`, `reauth_on_status`, and `validate_url` fields are reserved
+  but are not currently enforced.
+- Multi-step requests cannot define arbitrary per-step headers. Provider
+  endpoints requiring Basic auth, `Origin`, or SDK-specific headers may need an
+  authorized server-side test endpoint or a pre-acquired static token. Do not
+  put provider secrets in the URL.
+- Variable substitution applies to subsequent step URLs and bodies only.
 
 ### Multiple Extract Rules
 

--- a/public/vigolium-configs.example.yaml
+++ b/public/vigolium-configs.example.yaml
@@ -188,7 +188,7 @@ scanning_strategy:
   # --------------------------------------------------------------------------
   # Controls how authentication sessions behave during scanning.
   # Sessions are loaded from --auth-file or --auth flags.
-  # See docs/running-scan/authenticated-scan.md for the full guide.
+  # See docs/native-scan/authentication.md for the full guide.
   session:
     # Directory where session YAML files are stored.
     # When --auth-file receives a bare name (e.g. "myapp"), the scanner
@@ -215,30 +215,15 @@ scanning_strategy:
     # Default: true
     compare_enabled: true
 
-    # Re-execute login flows at this interval to refresh expiring tokens.
-    # Useful for long-running scans where tokens expire mid-scan.
-    # Format: Go duration string (e.g. "15m", "1h", "30m").
-    # Empty or "0" means login once at scan start and never refresh.
-    # Default: "" (disabled)
+    # Reserved for future runtime reauthentication. Native scans currently
+    # hydrate login flows once during initialization and do not enforce this.
     reauth_interval: ""
 
-    # Trigger reactive re-authentication when the primary session receives
-    # one of these HTTP status codes. When triggered, the login flow is
-    # re-executed immediately and the failed request is retried.
-    # Common values: [401, 403]
-    # Default: [] (disabled)
+    # Reserved for future reactive reauthentication; currently not enforced.
     reauth_on_status: []
-    # Example: re-authenticate on 401 Unauthorized and 403 Forbidden:
-    # reauth_on_status: [401, 403]
 
-    # URL to GET after login to verify that extracted credentials work.
-    # The scanner checks for a 2xx response before proceeding with the scan.
-    # Can be a relative path (resolved against the target) or absolute URL.
-    # Empty means no validation — credentials are used as-is.
-    # Default: "" (disabled)
+    # Reserved for future post-login validation; currently not enforced.
     validate_url: ""
-    # Example: validate against a "who am I" endpoint:
-    # validate_url: "/api/me"
 
   # --------------------------------------------------------------------------
   # Native Scan Session Logs


### PR DESCRIPTION
Doc update based on working session with codex getting vigolium working on an google sign in flow. Code + PR below is reviewed by me but AI generated.


------
## Summary

- document sequential login flows that pass extracted variables into a final application-token exchange
- add a reusable identity-provider token-exchange session preset and align the embedded CLI, autopilot, and scanner-skill examples
- clarify that runtime reauthentication, post-login validation, arbitrary per-step headers, and multi-step `auth load` persistence are not currently implemented

## Why

The authentication guidance described reserved session settings as active behavior and did not fully explain the implemented `login.steps` workflow. That could lead users to expect token refresh or validation that native scans do not perform, or to persist a multi-step configuration through `auth load` and lose its step topology.

This update documents the behavior the scanner actually supports and provides an environment-variable-based token-exchange example that can be passed directly with `--auth-file`.

## Impact

This is a documentation and example-only change; scanner runtime behavior is unchanged. Users get a complete multi-step authentication recipe and clearer boundaries around currently reserved functionality.

## Validation

- `go test ./pkg/authentication ./internal/config`
- `go test -tags=jstangle_stub ./pkg/cli`
- `git diff --cached --check`
